### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - To witness the full power of the logging check out `AKANetworkLogger.h`. This class is the pie, the rest is gravy.
 - To easily integrate the logging with a network request framework that emits sensible notifications subclass `AKANetworkNotificationLogger`.
-- To run the example project; clone the repo, and run `pod install` from the Example directory first. Except for that won't help because I am still learning how to make the example work with Cocoapods.
+- To run the example project; clone the repo, and run `pod install` from the Example directory first. Except for that won't help because I am still learning how to make the example work with CocoaPods.
 - To run the tests umm... Tests are coming soon also.
 
 ## Installation


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
